### PR TITLE
Add new entry point with database migration to backend

### DIFF
--- a/sdctools-service/deploy.py
+++ b/sdctools-service/deploy.py
@@ -1,0 +1,17 @@
+import os
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'BackendApi.settings')
+try:
+    from django.core.management import execute_from_command_line
+except ImportError as exc:
+    raise ImportError(
+        "Couldn't import Django. Are you sure it's installed and "
+        "available on your PYTHONPATH environment variable? Did you "
+        "forget to activate a virtual environment?"
+    ) from exc
+
+execute_from_command_line(['manage.py', 'makemigrations'])
+execute_from_command_line(['manage.py', 'migrate'])
+# execute_from_command_line(['manage.py', 'runserver'])
+
+from BackendApi import application


### PR DESCRIPTION
Now the backend deployment server runs database migration at the beginning of each deployment.